### PR TITLE
use sys._getframe instead of traceback.extract_stack for caller name

### DIFF
--- a/tos/clientv2.py
+++ b/tos/clientv2.py
@@ -12,7 +12,6 @@ import socket
 import sys
 import tempfile
 import time
-import traceback
 import urllib.parse
 import uuid
 from datetime import datetime
@@ -4257,7 +4256,7 @@ class TosClientV2(TosClient):
              generic_input=None,account_id=None,is_control_req=None):
         consume_body()
         # 获取调用方法的名称
-        func_name = func or traceback.extract_stack()[-2][2]
+        func_name = func or sys._getframe(1).f_code.co_name
         if key is not None and is_control_req is None:
             _is_valid_object_name(key)
         key = to_str(key)

--- a/tos/vector_client.py
+++ b/tos/vector_client.py
@@ -1,7 +1,7 @@
 import json
 import random
+import sys
 import time
-import traceback
 from typing import Dict, List, Any
 
 import requests
@@ -115,7 +115,7 @@ class VectorClient():
              generic_input=None, account_id=None):
         consume_body()
         # 获取调用方法的名称
-        func_name = func or traceback.extract_stack()[-2][2]
+        func_name = func or sys._getframe(1).f_code.co_name
 
         headers = _to_case_insensitive_dict(headers)
         params = _sanitize_dict(params)


### PR DESCRIPTION
`traceback.extract_stack()[-2][2]` 需要遍历整个调用栈，调用 `os.stat()` 读取所有相关源文件的的信息，性能非常差。

在我们遇到的 `os.stat()` lock contentation 情况下，每个 `get_object()` 调用有 1/3 的时间花在了 `extract_stack()`

<img width="2559" height="334" alt="image" src="https://github.com/user-attachments/assets/16ea14ae-8cc1-44d9-9b3f-4d48d50eb14f" />
